### PR TITLE
[WIP] Html encoding

### DIFF
--- a/src/html/Parser.php
+++ b/src/html/Parser.php
@@ -45,12 +45,16 @@ class Parser
         return $result;
     }
 
-    private function parseFull( $html )
+    private function parseFull( $html, $encoding = 'UTF-8')
     {
         $dom = new \DomDocument('1.0', $encoding);
         $prefix = '';
         if ( isset($encoding) ) {
-            $prefix  = "<head id='ar_html_parser_encoding_header'><meta charset='$encoding'></head>";
+            $prefix  = <<<EOS
+<head id='ar_html_parser_encoding_header'>
+<meta http-equiv="content-type" content="text/html; charset=$encoding">
+</head>
+EOS;
         }
         libxml_disable_entity_loader(); // prevents XXE attacks
         $prevErrorSetting = libxml_use_internal_errors(true);

--- a/src/html/Parser.php
+++ b/src/html/Parser.php
@@ -2,13 +2,13 @@
 
 namespace arc\html;
 
-class Parser 
+class Parser
 {
     public $options = [
         'libxml_options' => 0
     ];
 
-    public function __construct( $options = array() ) 
+    public function __construct( $options = array() )
     {
         $optionList = [ 'libxml_options' ];
         foreach( $options as $option => $optionValue ) {
@@ -18,7 +18,7 @@ class Parser
         }
     }
 
-    public function parse( $html, $encoding = null ) 
+    public function parse( $html, $encoding = 'UTF-8' )
     {
         if ( !$html ) {
             return \arc\html\Proxy( null );
@@ -29,12 +29,12 @@ class Parser
         $html = (string) $html;
         if ( stripos($html, '<html>')!==false ) {
             return $this->parseFull( $html, $encoding );
-        } else {        
+        } else {
             return $this->parsePartial( $html, $encoding );
         }
     }
 
-    private function parsePartial( $html, $encoding ) 
+    private function parsePartial( $html, $encoding = 'UTF-8')
     {
         $result = $this->parseFull( '<div id="ArcPartialHTML">'.$html.'</div>', $encoding );
         if ( $result ) {
@@ -45,12 +45,22 @@ class Parser
         return $result;
     }
 
-    private function parseFull( $html ) 
+    private function parseFull( $html )
     {
-        $dom = new \DomDocument();
+        $dom = new \DomDocument('1.0', $encoding);
+        $prefix = '';
+        if ( isset($encoding) ) {
+            $prefix  = "<head id='ar_html_parser_encoding_header'><meta charset='$encoding'></head>";
+        }
         libxml_disable_entity_loader(); // prevents XXE attacks
         $prevErrorSetting = libxml_use_internal_errors(true);
-        if ( $dom->loadHTML( $html, $this->options['libxml_options'] ) ) {
+        if ( $dom->loadHTML( $prefix . $html, $this->options['libxml_options'] ) ) {
+            if ( isset($encoding) ) {
+                $elm  = $dom->getElementById('ar_html_parser_encoding_header');
+                if ( isset($elm) ) {
+                    $elm->parentNode->removeChild($elm);
+                }
+            }
             libxml_use_internal_errors( $prevErrorSetting );
             return new \arc\html\Proxy( simplexml_import_dom( $dom ), $this );
         }

--- a/tests/html.Test.php
+++ b/tests/html.Test.php
@@ -36,9 +36,9 @@ EOS;
     function testHTMLBasics()
     {
         $doctype = \arc\html::doctype();
-        $this->assertEquals( (string) $doctype, '<!doctype html>' );
+        $this->assertEquals('<!doctype html>' ,  (string) $doctype);
         $comment = \arc\html::comment('A comment');
-        $this->assertEquals( (string) $comment, '<!-- A comment -->' );
+        $this->assertEquals('<!-- A comment -->' ,  (string) $comment);
     }
 
     function testHTMLWriter()
@@ -62,7 +62,7 @@ EOS;
         $error = null;
         $htmlString = ''.$html;
         $html2 = \arc\html::parse( $htmlString );
-        $this->assertEquals( $html->head->title, '<title>Example</title>' );
+        $this->assertEquals('<title>Example</title>' ,  $html->head->title);
         $this->assertTrue( $html->head->title->nodeValue == 'Example' );
         $this->assertEquals( $html->head->title.'', $html2->head->title.'' );
         $this->assertTrue( $html->head->title->nodeValue == 'Example' );
@@ -72,26 +72,26 @@ EOS;
     {
         $html = \arc\html::parse( $this->html1 );
         $title = $html->find('head title')[0];
-        $this->assertEquals( $title->nodeValue, 'Example' );
+        $this->assertEquals('Example' ,  $title->nodeValue);
     }
 
     function testDomMethods()
     {
         $html = \arc\html::parse( $this->html1 );
         $title = $html->getElementsByTagName('title')[0];
-        $this->assertEquals( $title->nodeValue, 'Example' );
+        $this->assertEquals('Example' ,  $title->nodeValue);
     }
 
 	function testEncoding() {
 		$html = \arc\html::parse( $this->html1, 'UTF-8' );
 		$elm = $html->find('#utf8')[0];
-		$this->assertEquals($this->i18n, $elm->nodeValue );
+		$this->assertTrue($elm->nodeValue == $this->i18n, "utf-8 text is not the same");
 	}
 
 	function testEntities() {
 		$html = \arc\html::parse( $this->html1, 'UTF-8' );
 		$elm = $html->find('#entities')[0];
-		$this->assertEquals($this->entities, $elm->nodeValue );
+		$this->assertTrue($elm->nodeValue == $this->entities, "Entities are no longer encoded");
 	}
 
 }

--- a/tests/html.Test.php
+++ b/tests/html.Test.php
@@ -9,23 +9,31 @@
  * file that was distributed with this source code.
  */
 
- 
-class TestHTML extends PHPUnit_Framework_TestCase 
+
+class TestHTML extends PHPUnit_Framework_TestCase
 {
+	private $i18n      = 'Iñtërnâtiônàlizætiøn';
+	private $entities  = "I&ntilde;t&euml;rn&acirc;ti&ocirc;n&agrave;liz&aelig;ti&oslash;n";
+	private $html1     = '';
 
-	var $html1 = '<html>
-    <head>
-        <title>Example</title>
-    </head>
-    <body>
-        <h1>Example Title</h1>
-        <hr>
-        <p>A paragraph</p>
-    </body>
+	function setup() {
+		$this->html1 = <<<EOS
+<html>
+	<head>
+		<title>Example</title>
+	</head>
+	<body>
+		<h1>Example Title</h1>
+		<hr>
+		<p>A paragraph</p>
+		<p id="utf8">{$this->i18n}</p>
+		<p id="entities">{$this->entities}</p>
+	</body>
 </html>
-';
+EOS;
+	}
 
-    function testHTMLBasics() 
+    function testHTMLBasics()
     {
         $doctype = \arc\html::doctype();
         $this->assertEquals( (string) $doctype, '<!doctype html>' );
@@ -33,7 +41,7 @@ class TestHTML extends PHPUnit_Framework_TestCase
         $this->assertEquals( (string) $comment, '<!-- A comment -->' );
     }
 
-    function testHTMLWriter() 
+    function testHTMLWriter()
     {
         $html = \arc\html::ul( [ 'class' => 'menu' ],
             \arc\html::li('menu 1 ',
@@ -41,14 +49,14 @@ class TestHTML extends PHPUnit_Framework_TestCase
             )
             ->li('menu 2')
         );
-        $this->assertEquals( 
+        $this->assertEquals(
             "<ul class=\"menu\">\r\n\t<li>\r\n\t\tmenu 1 <input type=\"radio\" checked>\r\n\t</li>"
             ."\r\n\t<li>menu 2</li>\r\n</ul>",
             ''.$html
         );
     }
 
-    function testHTMLParsing() 
+    function testHTMLParsing()
     {
         $html = \arc\html::parse( $this->html1 );
         $error = null;
@@ -60,7 +68,7 @@ class TestHTML extends PHPUnit_Framework_TestCase
         $this->assertTrue( $html->head->title->nodeValue == 'Example' );
     }
 
-    function testHTMLFind() 
+    function testHTMLFind()
     {
         $html = \arc\html::parse( $this->html1 );
         $title = $html->find('head title')[0];
@@ -73,5 +81,17 @@ class TestHTML extends PHPUnit_Framework_TestCase
         $title = $html->getElementsByTagName('title')[0];
         $this->assertEquals( $title->nodeValue, 'Example' );
     }
+
+	function testEncoding() {
+		$html = \arc\html::parse( $this->html1, 'UTF-8' );
+		$elm = $html->find('#utf8')[0];
+		$this->assertEquals($this->i18n, $elm->nodeValue );
+	}
+
+	function testEntities() {
+		$html = \arc\html::parse( $this->html1, 'UTF-8' );
+		$elm = $html->find('#entities')[0];
+		$this->assertEquals($this->entities, $elm->nodeValue );
+	}
 
 }


### PR DESCRIPTION
domdocument doens't understand utf-8 when handling html
This tries to work around this problem

work:
- [x] default encoding to utf-8
- [x] test with entities and utf8
- [ ] fix that entities stay entities
- [x] check that the extra head is removed
- [ ] test with html with charset in the head
